### PR TITLE
Draft releases automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Release
+
+jobs:
+  release:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+            node-version: 22.x
+
+      - run: npm install
+
+      - run: npm run package
+
+      - name: Create Release and Upload Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: ahkunit-*.vsix
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # The default token has necessary permissions


### PR DESCRIPTION
Draft a release automatically when tags starting in "v" are pushed. This does mean that the GitHub UI isn't going to work for new releases.