### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   test:
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/holy-tao/ahkunit/security/code-scanning/1](https://github.com/holy-tao/ahkunit/security/code-scanning/1)

To fix the problem, the `test` job needs an explicit `permissions` block to restrict the `GITHUB_TOKEN` to the least privilege required. Since the `test` job only checks out the repository and runs tests, it only needs read access to repository contents, so `contents: read` is sufficient.

Concretely, in `.github/workflows/ci.yml`, under `jobs:`, locate the `test:` job definition (starting at line 27). Add a `permissions:` section at the same indentation level as `strategy:` and `runs-on:`, and set `contents: read`. No other changes, imports, or additional methods are required, and this will not affect the existing steps’ behavior because they already only need read access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
