### PR TITLE
Use a less specific activation event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ahkunit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ahkunit",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",

--- a/package.json
+++ b/package.json
@@ -3,22 +3,22 @@
   "displayName": "AHKUnit",
   "description": "Unit test support for AutoHotkey V2",
   "categories": [
-      "Testing"
+    "Testing"
   ],
   "keywords": [
-      "vscode",
-      "autohotkey",
-      "ahk",
-      "ahk2",
-      "test"
+    "vscode",
+    "autohotkey",
+    "ahk",
+    "ahk2",
+    "test"
   ],
   "license": "See license in LICENSE",
   "preview": true,
   "homepage": "https://github.com/holy-tao/ahkunit/blob/main/README.md",
   "bugs": {
-      "url": "https://github.com/holy-tao/ahkunit/issues"
+    "url": "https://github.com/holy-tao/ahkunit/issues"
   },
-   "galleryBanner": {
+  "galleryBanner": {
     "color": "#00769D",
     "theme": "dark"
   },
@@ -26,7 +26,7 @@
     "type": "github",
     "url": "https://github.com/holy-tao/ahkunit"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "engines": {
     "vscode": "^1.108.0"
   },


### PR DESCRIPTION
Since the test identifier glob pattern is configurable, we can't use it
as an activation event. Instead, activate whenever the open workspace
contains .ahk or .ahk2 files