### PR TITLE
Dependabot: group updates by ecosystem and ignore major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+    ignore:
+      # Skip major version bumps — handle these manually
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group updates by package ecosystem and ignore major updates on the assumption that they will always require manual intervention.

Should reduce noise from dependabot PRs.